### PR TITLE
Enable QEMU

### DIFF
--- a/.github/actions/docker-build-github/action.yml
+++ b/.github/actions/docker-build-github/action.yml
@@ -10,6 +10,10 @@ inputs:
     required: true
     default: ./Dockerfile
     description: The docker file to use when building the image
+  platforms:
+    required: false
+    default: linux/amd64
+    description: The platforms to build for
   github_token:
     required: true
     description: A token used by the Dockerfile
@@ -41,6 +45,9 @@ runs:
         echo "TAGS: ${{ steps.metadata.outputs.tags }}"
         echo "LABELS: ${{ steps.metadata.outputs.labels }}"
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx to enable caching
       uses: docker/setup-buildx-action@v3
 
@@ -48,6 +55,7 @@ runs:
       uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: ${{ inputs.platforms }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
         file: ${{ inputs.dockerfile }}
@@ -61,6 +69,6 @@ runs:
         echo "Built docker image:" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
         echo "- Name: ${{ inputs.image_name }}" >> $GITHUB_STEP_SUMMARY
-        echo "- TAGS: ${{ steps.metadata.outputs.tags }},${{ inputs.image_name }}:latest" >> $GITHUB_STEP_SUMMARY
+        echo "- TAGS: ${{ steps.metadata.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
         echo "- LABELS: ${{ steps.metadata.outputs.labels }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line


### PR DESCRIPTION
Enable QEMU to add support for building docker images for multiple platforms through the `platforms` input variable. Default value is `linux/amd64`